### PR TITLE
Correct typo in test file comment

### DIFF
--- a/utf8tests.txt
+++ b/utf8tests.txt
@@ -30,7 +30,7 @@
 # num:invalid hex:hexString:hexString2:hexString3
 
 # * hexString2 is the expected value when skipping invalid bytes.
-# * hexString2 is the expected value when replacing invalid bytes with U+FFFD.
+# * hexString3 is the expected value when replacing invalid bytes with U+FFFD.
 
 
 


### PR DESCRIPTION
While reviewing the test file I noted that `hexString2` appears to be accidentally repeated twice. The use in context is clear, but it’s confusing that the instructions currently provide two different explanations for the same field.